### PR TITLE
Replaced cookie with local storage

### DIFF
--- a/src/StationContext.tsx
+++ b/src/StationContext.tsx
@@ -1,6 +1,6 @@
 import { FC, createContext, useCallback, useEffect, useState } from 'react';
 import { CurrentResponse, getCurrentConditions } from './api/getCurrentConditions';
-import { getCookie } from 'typescript-cookie';
+//import { getCookie } from 'typescript-cookie';
 
 interface OwnProps {
   children: React.ReactNode;
@@ -37,7 +37,8 @@ const StationProvider: FC<OwnProps> = ({ children }) => {
 
 
   useEffect(() => {
-    const id = getCookie('stationID');
+    //const id = getCookie('stationID');
+    const id = window.localStorage.getItem('stationID');
 
     if (id && id !== stationID) {
       setStationID(id);

--- a/src/components/SetupPage.tsx
+++ b/src/components/SetupPage.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, Modal, Space, Typography } from "antd";
 import { FC, useContext, useState } from "react";
-import { setCookie } from "typescript-cookie";
+//import { setCookie } from "typescript-cookie";
 import { StationContext } from "../StationContext";
 
 interface Props {
@@ -13,7 +13,8 @@ const SetupPage: FC<Props> = ({ isOpen, setIsOpen }) => {
     const [id, setID] = useState('');
 
     const save = () => {
-        setCookie('stationID', id);
+        //setCookie('stationID', id);
+        window.localStorage.setItem('stationID', id);
         setStationID(id);
         setIsOpen(false);
     };

--- a/src/pages/SettingsDrawer.tsx
+++ b/src/pages/SettingsDrawer.tsx
@@ -1,7 +1,7 @@
 import { Button, Checkbox, Drawer, Input, Space, Typography } from "antd";
 import { FC, useContext, useEffect, useState } from "react";
 import { StationContext } from "../StationContext";
-import { setCookie } from "typescript-cookie";
+//import { setCookie } from "typescript-cookie";
 
 interface Props {
     isOpen: boolean;
@@ -22,7 +22,8 @@ const SettingsDrawer: FC<Props> = ({isOpen, setIsOpen}) => {
         setStationID(newID);
 
         if (saveID) {
-            setCookie('stationID', newID);
+            //setCookie('stationID', newID);
+            window.localStorage.setItem('stationID', newID);
         }
 
         setIsOpen(false);


### PR DESCRIPTION
Cookies were not being saved when the device reboots. If the website was saved as an app/Home Screen shortcut and the device restarted, it would lose the cookie. We're trying local storage now to see if that works better. 